### PR TITLE
Add the default project templates we are going to use in this project

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+Contributing
+============
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+If you would like to contribute code to this repository you can do so through GitHub by
+forking the repository and sending a pull request or opening an issue.
+
+When submitting code, please make every effort to follow existing conventions
+and style in order to keep the code as readable as possible. Please also make
+sure your code compiles, passes the tests and the checkstyle configured for this repository.
+
+
+Some tips that will help you to contribute to this repository:
+
+* Write clean code and test it.
+* Follow the repository code style.
+* Write good commit messages.
+* Do not send pull requests without checking if the project build is OK in Travis-CI.
+* Review if your changes affects the repository documentation and update it.
+* Describe the PR content and don't hesitate to add comments to explain us why you've added or changed something.
+
+Code of conduct
+---------------
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior can be reported by emailing hello@karumi.com.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org/version/1/3/0/), version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Expected behaviour
+
+
+### Actual behaviour
+
+
+### Steps to reproduce
+
+
+### Version of the library
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+### :pushpin: References
+* **Issue:** _your issue goes here_
+* **Related pull-requests:** _list of related pull-requests (comma-separated): #1, #2_
+
+### :tophat: What is the goal?
+
+_Provide a description of the overall goal (you can usually copy the one from the issue)_
+
+### How is it being implemented?
+
+_Provide a description of the implementation_
+
+### How can it be tested?
+
+_If it cannot be tested explain why._
+
+- [ ] **Use case 1:** _A brief description of the use case that should be tested_
+- [ ] **Use case 2:** _If the use case requires some complex steps, increase indentation_
+  - [ ] _Step 1_
+  - [ ] _Step 2_


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #4, #2.

### :tophat: What is the goal?

Improve the templates being used in the project when contributing with issues or pull requests.

### How is it being implemented?

We've added a new folder named ``.github`` where the three template files are located:

* CONTRIBUTING.md
* PULL_REQUEST_TEMPLATE.md
* ISSUE_TEMPLATE.md

### How can it be tested?

Let's review this PR.
